### PR TITLE
Refactor loading of configurations

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -50,6 +50,4 @@ jobs:
           role-session-name: ${{ inputs.role-session-name }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - name: CDK deploy
-        run: cdk deploy --all --debug --concurrency 5 --require-approval never
-        env:
-          ENV: ${{ inputs.environment }}
+        run: cdk deploy --context env=${{ inputs.environment }} --all --debug --concurrency 5 --require-approval never

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ execute the validations by running `pre-commit run --all-files`.
 Verify CDK to Cloudformation conversion by running [cdk synth]:
 
 ```console
-ENV=dev cdk synth
+cdk synth --context env=dev
 ```
 
 The Cloudformation output is saved to the `cdk.out` folder
@@ -102,38 +102,33 @@ python -m pytest tests/ -s -v
 
 ## Environments
 
-An `ENV` environment variable must be set when running the `cdk` command tell the
-CDK which environment's variables to use when synthesising or deploying the stacks.
+When running `cdk` commands, you must specify which environment's
+configuration to use.  This is done by passing a context variable to
+CDK, which loads environment-specific parameters.
 
-Set environment variables for each environment in the [app.py](./app.py) file:
+Create a configuration file in the [config](./config) folder for each environment
+(e.g., `dev.yaml`, `prod.yaml`).  Both yaml and json files are supported.
+The supported environments are dev, stage, and prod.
 
-```python
-environment_variables = {
-    "VPC_CIDR": "10.254.192.0/24",
-    "FQDN": "dev.app.io",
-    "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:XXXXXXXXXXX:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
-    "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-}
-```
-
-For example, synthesis with the `prod` environment variables:
+To synthesize or deploy using the `prod` environment configuration:
 
 ```console
-ENV=prod cdk synth
+cdk synth --context env=prod
 ```
 
+There is also an optional `base` configuration file that is always loaded
+and merged with one of the passed in environment configuration.
+
+The values from the environment-specific configuration file will
+override those in the base configuration file if there are conflicts.
+For example, if both files define `TAGS`, the value from `dev.yaml`
+will take precedence.
+
+
 > [!NOTE]
-> The `VPC_CIDR` must be a unique value within our AWS organization. Check our
-> [wiki](https://sagebionetworks.jira.com/wiki/spaces/IT/pages/2850586648/Setup+AWS+VPC)
-> for information on how to obtain a unique CIDR
-
-## Certificates
-
-Certificates to set up HTTPS connections should be created manually in AWS certificate manager.
-This is not automated due to AWS requiring manual verification of the domain ownership.
-Once created take the ARN of the certificate and set that ARN in environment_variables.
-
-![ACM certificate](docs/acm-certificate.png)
+> Ensure that `VPC_CIDR` is unique within your AWS organization.
+Refer to our [guidance](https://sagebionetworks.jira.com/wiki/spaces/IT/pages/2850586648/Setup+AWS+VPC)
+on selecting a unique CIDR block.
 
 ## Secrets
 
@@ -299,7 +294,7 @@ Deployment requires setting up an [AWS profile](https://docs.aws.amazon.com/cli/
 then executing the following command:
 
 ```console
-AWS_PROFILE=itsandbox-dev AWS_DEFAULT_REGION=us-east-1 ENV=dev cdk deploy --all
+AWS_PROFILE=itsandbox-dev AWS_DEFAULT_REGION=us-east-1 cdk deploy --context env=dev --all
 ```
 
 ## Force new deployment

--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-from os import environ
-
 import aws_cdk as cdk
 
 from src.database_stack import DatabaseStack
@@ -8,82 +6,52 @@ from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps
 from src.service_stack import LoadBalancedServiceStack, ServiceStack
+from src.utils import load_context_config
 
-# get the environment and set environment specific variables
-VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
-environment = environ.get("ENV")
-match environment:
-    case "prod":
-        environment_variables = {
-            "VPC_CIDR": "10.254.122.0/24",
-            "FQDN": "prod.bixarena.ai",
-            "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:045984464920:certificate/2d81bfca-89ea-42cb-8e78-ea9c3d1f6919",
-            "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-        }
-    case "stage":
-        environment_variables = {
-            "VPC_CIDR": "10.254.121.0/24",
-            "FQDN": "stage.bixarena.ai",
-            "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:045984464920:certificate/2d81bfca-89ea-42cb-8e78-ea9c3d1f6919",
-            "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-        }
-    case "dev":
-        environment_variables = {
-            "VPC_CIDR": "10.254.120.0/24",
-            "FQDN": "dev.bixarena.ai",
-            "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:864020296088:certificate/d82cd9ec-2106-4293-9232-62af18bb6295",
-            "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
-        }
-    case _:
-        valid_envs_str = ",".join(VALID_ENVIRONMENTS)
-        raise SystemExit(
-            f"Must set environment variable `ENV` to one of {valid_envs_str}. Currently set to {environment}."
-        )
-
-stack_name_prefix = f"bixarena-{environment}"
-fully_qualified_domain_name = environment_variables["FQDN"]
-environment_tags = environment_variables["TAGS"]
-app_version = "edge"
-
-# Define stacks
 cdk_app = cdk.App()
+env_name = cdk_app.node.try_get_context("env") or "dev"
+config = load_context_config(env_name=env_name)
+STACK_NAME_PREFIX = f"bixarena-{env_name}"
+FQDN = config["FQDN"]
+TAGS = config["TAGS"]
+CERTIFICATE_ARN = config["CERTIFICATE_ARN"]
+APP_VERSION = "edge"
 
 # recursively apply tags to all stack resources
-if environment_tags:
-    for key, value in environment_tags.items():
+if TAGS:
+    for key, value in TAGS.items():
         cdk.Tags.of(cdk_app).add(key, value)
 
 
 network_stack = NetworkStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-network",
-    vpc_cidr=environment_variables["VPC_CIDR"],
+    construct_id=f"{STACK_NAME_PREFIX}-network",
+    vpc_cidr=config["VPC_CIDR"],
 )
 
 database_stack = DatabaseStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-db",
+    construct_id=f"{STACK_NAME_PREFIX}-db",
     vpc=network_stack.vpc,
     allocated_storage=50,
 )
 
-
 ecs_stack = EcsStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-ecs",
+    construct_id=f"{STACK_NAME_PREFIX}-ecs",
     vpc=network_stack.vpc,
-    namespace=fully_qualified_domain_name,
+    namespace=FQDN,
 )
 
 api_props = ServiceProps(
     container_name="bixarena-api",
-    container_location=f"ghcr.io/sage-bionetworks/bixarena-api:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/bixarena-api:{APP_VERSION}",
     container_port=8112,
     ecs_task_memory=1024,
 )
 api_stack = ServiceStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-api",
+    construct_id=f"{STACK_NAME_PREFIX}-api",
     vpc=network_stack.vpc,
     cluster=ecs_stack.cluster,
     props=api_props,
@@ -93,10 +61,9 @@ api_stack.service.connections.allow_to_default_port(
     database_stack.database,
     "Allow API container to connect to database",
 )
-
 ai_service_props = ServiceProps(
     container_name="bixarena-ai-service",
-    container_location=f"ghcr.io/sage-bionetworks/bixarena-ai-service:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/bixarena-ai-service:{APP_VERSION}",
     container_port=8114,
     container_env_vars={
         "APP_PORT": "8114",
@@ -105,7 +72,7 @@ ai_service_props = ServiceProps(
 )
 ai_service_stack = ServiceStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-ai-service",
+    construct_id=f"{STACK_NAME_PREFIX}-ai-service",
     vpc=network_stack.vpc,
     cluster=ecs_stack.cluster,
     props=ai_service_props,
@@ -118,13 +85,13 @@ ai_service_stack.service.connections.allow_to_default_port(
 
 api_gateway_props = ServiceProps(
     container_name="bixarena-api-gateway",
-    container_location=f"ghcr.io/sage-bionetworks/bixarena-api-gateway:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/bixarena-api-gateway:{APP_VERSION}",
     container_port=8113,
     ecs_task_memory=1024,
 )
 api_gateway_stack = ServiceStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-api-gateway",
+    construct_id=f"{STACK_NAME_PREFIX}-api-gateway",
     vpc=network_stack.vpc,
     cluster=ecs_stack.cluster,
     props=api_gateway_props,
@@ -139,26 +106,27 @@ api_gateway_stack.add_dependency(ai_service_stack)
 # client service is running and available the public, but a backend isn't.
 load_balancer_stack = LoadBalancerStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-load-balancer",
+    construct_id=f"{STACK_NAME_PREFIX}-load-balancer",
     vpc=network_stack.vpc,
 )
+load_balancer_stack.add_dependency(ecs_stack)
 
 app_props = ServiceProps(
     container_name="bixarena-app",
-    container_location=f"ghcr.io/sage-bionetworks/bixarena-app:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/bixarena-app:{APP_VERSION}",
     container_port=8100,
     ecs_task_memory=1024,
     container_env_vars={
         "APP_PORT": "8100",
         "ENVIRONMENT": "development",
-        "API_BASE_URL": f"https://{fully_qualified_domain_name}/v1",
+        "API_BASE_URL": f"https://{FQDN}/v1",
         "OIDC_BASE_URL": "http://127.0.0.1:8112/v1",
         "OPENAI_API_KEY": "changeme",
     },
 )
 app_stack = ServiceStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-app",
+    construct_id=f"{STACK_NAME_PREFIX}-app",
     vpc=network_stack.vpc,
     cluster=ecs_stack.cluster,
     props=app_props,
@@ -167,7 +135,7 @@ app_stack.add_dependency(api_stack)
 
 apex_props = ServiceProps(
     container_name="bixarena-apex",
-    container_location=f"ghcr.io/sage-bionetworks/bixarena-apex:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/bixarena-apex:{APP_VERSION}",
     container_port=8111,
     container_env_vars={
         "API_GATEWAY_HOST": "bixarena-api-gateway",
@@ -178,12 +146,12 @@ apex_props = ServiceProps(
 )
 apex_stack = LoadBalancedServiceStack(
     scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-apex",
+    construct_id=f"{STACK_NAME_PREFIX}-apex",
     vpc=network_stack.vpc,
     cluster=ecs_stack.cluster,
     props=apex_props,
     load_balancer=load_balancer_stack.alb,
-    certificate_arn=environment_variables["CERTIFICATE_ARN"],
+    certificate_arn=CERTIFICATE_ARN,
 )
 apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_gateway_stack)

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,0 +1,2 @@
+TAGS:
+  CostCenter: NO PROGRAM / 000000

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -1,0 +1,4 @@
+VPC_CIDR: 10.254.120.0/24
+FQDN: dev.bixarena.ai
+CERTIFICATE_ARN: >-
+  arn:aws:acm:us-east-1:864020296088:certificate/d82cd9ec-2106-4293-9232-62af18bb6295

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,0 +1,4 @@
+VPC_CIDR: 10.254.122.0/24
+FQDN: prod.bixarena.ai
+CERTIFICATE_ARN: >-
+  arn:aws:acm:us-east-1:045984464920:certificate/2d81bfca-89ea-42cb-8e78-ea9c3d1f6919

--- a/config/stage.yaml
+++ b/config/stage.yaml
@@ -1,0 +1,4 @@
+VPC_CIDR: 10.254.121.0/24
+FQDN: stage.bixarena.ai
+CERTIFICATE_ARN: >-
+  arn:aws:acm:us-east-1:045984464920:certificate/2d81bfca-89ea-42cb-8e78-ea9c3d1f6919

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib==2.220.0
 constructs>=10.0.0,<11.0.0
 boto3>=1.40.55
+pyYAML>=6.0

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,67 @@
+import json
+import yaml
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_context_config(env_name: str, config_dir: str = "config") -> Dict[str, Any]:
+    """
+    Load AWS CDK context configuration from a YAML or JSON file.
+    Supports:
+      - .yaml/.yml OR .json (but not both)
+      - base.yaml merged with environment config
+      - Only 'dev', 'stage', or 'prod' environments are valid
+    Raises:
+      - ValueError if environment is invalid or multiple config files exist
+      - FileNotFoundError if expected config file not found
+    """
+
+    # ✅ Validate environment name
+    valid_envs = {"dev", "stage", "prod"}
+    if env_name not in valid_envs:
+        raise ValueError(
+            f"Invalid environment '{env_name}'. "
+            f"Must be one of: {', '.join(sorted(valid_envs))}"
+        )
+
+    # Define possible config paths
+    base_path = Path(config_dir) / "base.yaml"
+    env_yaml = Path(config_dir) / f"{env_name}.yaml"
+    env_yml = Path(config_dir) / f"{env_name}.yml"
+    env_json = Path(config_dir) / f"{env_name}.json"
+
+    def read_file(path: Path) -> Dict[str, Any]:
+        """Read YAML or JSON file into a dictionary."""
+        with open(path, "r") as f:
+            if path.suffix in (".yaml", ".yml"):
+                return yaml.safe_load(f) or {}
+            elif path.suffix == ".json":
+                return json.load(f)
+            else:
+                raise ValueError(f"Unsupported config file type: {path.suffix}")
+
+    # Load base config (optional)
+    base_config = {}
+    if base_path.exists():
+        base_config = read_file(base_path)
+
+    # Detect existing env-specific file(s)
+    env_files = [p for p in [env_yaml, env_yml, env_json] if p.exists()]
+
+    if not env_files:
+        raise FileNotFoundError(
+            f"No config file found for environment '{env_name}' "
+            f"in {config_dir}. Expected one of: {env_yaml}, {env_yml}, {env_json}"
+        )
+
+    if len(env_files) > 1:
+        raise ValueError(
+            f"Multiple config files found for environment '{env_name}': {env_files}. "
+            f"Use only one (.yaml/.yml OR .json)."
+        )
+
+    # Load and merge configs
+    env_config = read_file(env_files[0])
+    merged_config = {**base_config, **env_config}
+
+    return merged_config

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,259 @@
+import json
+import pytest
+import tempfile
+import yaml
+from pathlib import Path
+
+from src.utils import load_context_config
+
+
+class TestLoadContextConfig:
+    """Test suite for the load_context_config function."""
+
+    def test_invalid_environment_raises_value_error(self):
+        """Test that invalid environment names raise ValueError."""
+        invalid_envs = ["invalid", "test", "production", "development", ""]
+
+        for env in invalid_envs:
+            with pytest.raises(ValueError, match=f"Invalid environment '{env}'"):
+                load_context_config(env)
+
+    def test_valid_environments(self):
+        """Test that valid environment names are accepted."""
+        valid_envs = ["dev", "stage", "prod"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a basic config file for each valid environment
+            for env in valid_envs:
+                config_file = Path(temp_dir) / f"{env}.yaml"
+                with open(config_file, "w") as f:
+                    yaml.dump({"test": "value"}, f)
+
+                # Should not raise an exception
+                result = load_context_config(env, temp_dir)
+                assert result == {"test": "value"}
+
+    def test_no_config_file_raises_file_not_found_error(self):
+        """Test that missing config files raise FileNotFoundError."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with pytest.raises(
+                FileNotFoundError, match="No config file found for environment 'dev'"
+            ):
+                load_context_config("dev", temp_dir)
+
+    def test_multiple_config_files_raises_value_error(self):
+        """Test that multiple config files for same environment raise ValueError."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create multiple config files for the same environment
+            yaml_file = Path(temp_dir) / "dev.yaml"
+            json_file = Path(temp_dir) / "dev.json"
+
+            with open(yaml_file, "w") as f:
+                yaml.dump({"test": "yaml"}, f)
+
+            with open(json_file, "w") as f:
+                json.dump({"test": "json"}, f)
+
+            with pytest.raises(
+                ValueError, match="Multiple config files found for environment 'dev'"
+            ):
+                load_context_config("dev", temp_dir)
+
+    def test_load_yaml_config(self):
+        """Test loading YAML configuration file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "dev.yaml"
+            config_data = {
+                "VPC_CIDR": "10.0.0.0/16",
+                "FQDN": "example.com",
+                "TAGS": {"Environment": "dev"},
+            }
+
+            with open(config_file, "w") as f:
+                yaml.dump(config_data, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result == config_data
+
+    def test_load_yml_config(self):
+        """Test loading .yml configuration file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "dev.yml"
+            config_data = {"VPC_CIDR": "10.0.0.0/16", "FQDN": "example.com"}
+
+            with open(config_file, "w") as f:
+                yaml.dump(config_data, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result == config_data
+
+    def test_load_json_config(self):
+        """Test loading JSON configuration file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "dev.json"
+            config_data = {
+                "VPC_CIDR": "10.0.0.0/16",
+                "FQDN": "example.com",
+                "TAGS": {"Environment": "dev"},
+            }
+
+            with open(config_file, "w") as f:
+                json.dump(config_data, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result == config_data
+
+    def test_base_config_merging(self):
+        """Test that base.yaml is properly merged with environment config."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create base config
+            base_file = Path(temp_dir) / "base.yaml"
+            base_config = {
+                "VPC_CIDR": "10.0.0.0/16",
+                "COMMON_SETTING": "base_value",
+                "SHARED_SETTING": "from_base",
+            }
+            with open(base_file, "w") as f:
+                yaml.dump(base_config, f)
+
+            # Create environment config
+            env_file = Path(temp_dir) / "dev.yaml"
+            env_config = {
+                "FQDN": "dev.example.com",
+                "SHARED_SETTING": "from_env",  # This should override base
+                "ENV_SPECIFIC": "dev_value",
+            }
+            with open(env_file, "w") as f:
+                yaml.dump(env_config, f)
+
+            result = load_context_config("dev", temp_dir)
+
+            expected = {
+                "VPC_CIDR": "10.0.0.0/16",  # from base
+                "COMMON_SETTING": "base_value",  # from base
+                "SHARED_SETTING": "from_env",  # env overrides base
+                "FQDN": "dev.example.com",  # from env
+                "ENV_SPECIFIC": "dev_value",  # from env
+            }
+
+            assert result == expected
+
+    def test_no_base_config(self):
+        """Test loading config when base.yaml doesn't exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = Path(temp_dir) / "dev.yaml"
+            env_config = {"FQDN": "dev.example.com"}
+
+            with open(env_file, "w") as f:
+                yaml.dump(env_config, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result == env_config
+
+    def test_empty_base_config(self):
+        """Test handling of empty base config file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create empty base config
+            base_file = Path(temp_dir) / "base.yaml"
+            with open(base_file, "w") as f:
+                f.write("")  # Empty file
+
+            # Create environment config
+            env_file = Path(temp_dir) / "dev.yaml"
+            env_config = {"FQDN": "dev.example.com"}
+            with open(env_file, "w") as f:
+                yaml.dump(env_config, f)
+
+            result = load_context_config("dev", temp_dir)
+            assert result == env_config
+
+    def test_empty_env_config(self):
+        """Test handling of empty environment config file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create base config
+            base_file = Path(temp_dir) / "base.yaml"
+            base_config = {"VPC_CIDR": "10.0.0.0/16"}
+            with open(base_file, "w") as f:
+                yaml.dump(base_config, f)
+
+            # Create empty environment config
+            env_file = Path(temp_dir) / "dev.yaml"
+            with open(env_file, "w") as f:
+                f.write("")  # Empty file
+
+            result = load_context_config("dev", temp_dir)
+            assert result == base_config
+
+    def test_custom_config_dir(self):
+        """Test using a custom config directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            custom_dir = Path(temp_dir) / "custom_config"
+            custom_dir.mkdir()
+
+            config_file = custom_dir / "dev.yaml"
+            config_data = {"FQDN": "custom.example.com"}
+
+            with open(config_file, "w") as f:
+                yaml.dump(config_data, f)
+
+            result = load_context_config("dev", str(custom_dir))
+            assert result == config_data
+
+    def test_yaml_precedence_over_yml(self):
+        """Test that when both .yaml and .yml exist, an error is raised."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # This test ensures our error handling works - we should get an error
+            # when both .yaml and .yml exist
+            yaml_file = Path(temp_dir) / "dev.yaml"
+            yml_file = Path(temp_dir) / "dev.yml"
+
+            with open(yaml_file, "w") as f:
+                yaml.dump({"source": "yaml"}, f)
+
+            with open(yml_file, "w") as f:
+                yaml.dump({"source": "yml"}, f)
+
+            with pytest.raises(ValueError, match="Multiple config files found"):
+                load_context_config("dev", temp_dir)
+
+    def test_all_environments_work(self):
+        """Test that all valid environments work correctly."""
+        environments = ["dev", "stage", "prod"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for env in environments:
+                config_file = Path(temp_dir) / f"{env}.yaml"
+                config_data = {
+                    "FQDN": f"{env}.example.com",
+                    "VPC_CIDR": "10.0.0.0/16",
+                    "TAGS": {"Environment": env},
+                }
+
+                with open(config_file, "w") as f:
+                    yaml.dump(config_data, f)
+
+                result = load_context_config(env, temp_dir)
+                assert result["FQDN"] == f"{env}.example.com"
+                assert result["TAGS"]["Environment"] == env
+
+    def test_invalid_yaml_content(self):
+        """Test handling of invalid YAML content."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "dev.yaml"
+            # Create invalid YAML content
+            with open(config_file, "w") as f:
+                f.write("invalid: yaml: content: [unclosed")
+
+            with pytest.raises(yaml.YAMLError):
+                load_context_config("dev", temp_dir)
+
+    def test_invalid_json_content(self):
+        """Test handling of invalid JSON content."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "dev.json"
+            # Create invalid JSON content
+            with open(config_file, "w") as f:
+                f.write('{"invalid": json content}')
+
+            with pytest.raises(json.JSONDecodeError):
+                load_context_config("dev", temp_dir)


### PR DESCRIPTION
Use the AWS CDK built in context loader[1] and allow storing and loading configurations from files.

[1] https://docs.aws.amazon.com/cdk/v2/guide/context.html

This is a code refactor and should be a noop on deployment which was verified using the `cdk diff` command..
```
 ➜  AWS_PROFILE=bixarenadev-admin AWS_DEFAULT_REGION=us-east-1 cdk diff --context env=dev

start: Building bixarena-dev-network Template
success: Built bixarena-dev-network Template
start: Publishing bixarena-dev-network Template (current_account-current_region-1ef5d2ff)
success: Published bixarena-dev-network Template (current_account-current_region-1ef5d2ff)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-network
There were no differences

start: Building bixarena-dev-db Template
success: Built bixarena-dev-db Template
start: Publishing bixarena-dev-db Template (current_account-current_region-3c3b5736)
success: Published bixarena-dev-db Template (current_account-current_region-3c3b5736)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-db
There were no differences

start: Building bixarena-dev-ecs Template
success: Built bixarena-dev-ecs Template
start: Publishing bixarena-dev-ecs Template (current_account-current_region-283dc56e)
success: Published bixarena-dev-ecs Template (current_account-current_region-283dc56e)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-ecs
There were no differences

start: Building bixarena-dev-api Template
success: Built bixarena-dev-api Template
start: Publishing bixarena-dev-api Template (current_account-current_region-9c369072)
success: Published bixarena-dev-api Template (current_account-current_region-9c369072)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-api
There were no differences

start: Building bixarena-dev-ai-service Template
success: Built bixarena-dev-ai-service Template
start: Publishing bixarena-dev-ai-service Template (current_account-current_region-fb327b4e)
success: Published bixarena-dev-ai-service Template (current_account-current_region-fb327b4e)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-ai-service
There were no differences

start: Building bixarena-dev-api-gateway Template
success: Built bixarena-dev-api-gateway Template
start: Publishing bixarena-dev-api-gateway Template (current_account-current_region-4b608ed6)
success: Published bixarena-dev-api-gateway Template (current_account-current_region-4b608ed6)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-api-gateway
There were no differences

start: Building bixarena-dev-load-balancer Template
success: Built bixarena-dev-load-balancer Template
start: Publishing bixarena-dev-load-balancer Template (current_account-current_region-87c0d8c0)
success: Published bixarena-dev-load-balancer Template (current_account-current_region-87c0d8c0)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-load-balancer
There were no differences

start: Building bixarena-dev-app Template
success: Built bixarena-dev-app Template
start: Publishing bixarena-dev-app Template (current_account-current_region-f76dce49)
success: Published bixarena-dev-app Template (current_account-current_region-f76dce49)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-app
There were no differences

start: Building bixarena-dev-apex Template
success: Built bixarena-dev-apex Template
start: Publishing bixarena-dev-apex Template (current_account-current_region-500d5aa8)
success: Published bixarena-dev-apex Template (current_account-current_region-500d5aa8)
Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)

Stack bixarena-dev-apex
There were no differences


✨  Number of stacks with differences: 0
```