### PR TITLE
Fix command for CDK synth test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,4 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Generate cloudformation
-        env:
-          ENV: ${{ inputs.environment }}
-        run: cdk synth --debug --output ./cdk.out
+        run: cdk synth --context env=${{ inputs.environment }} --debug --output ./cdk.out


### PR DESCRIPTION
PR #8  changed to use the AWS CDK built in context loader but forgot to update the synth test.  Fixing the test to use the context loader.
